### PR TITLE
Fix: confidence values are sometimes floats as strings

### DIFF
--- a/pgsrip/tsv.py
+++ b/pgsrip/tsv.py
@@ -16,7 +16,7 @@ class TsvDataItem:
         self.top = int(top)
         self.width = int(width)
         self.height = int(height)
-        self.conf = int(conf)
+        self.conf = int(float(conf))  # cast to float first to handle strings passed by pytesseract<0.3.10
         self.text = text
 
     def __repr__(self):


### PR DESCRIPTION
fixes #3 

Newer versions of tesseract seem to be returning floating point confidence numbers, which pytesseract is not handling correctly yet. Casting to float first will work with current and future versions of pytesseract.