### PR TITLE
Added more options for specific uses cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ target/
 .idea
 
 main.py
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Version](https://img.shields.io/pypi/v/pgsrip.svg)](https://pypi.python.org/pypi
 
 [![License](https://img.shields.io/github/license/ratoaq2/pgsrip.svg)](https://github.com/ratoaq2/pgsrip/blob/master/LICENSE)
 
-  - Project page  
+  - Project page
     <https://github.com/ratoaq2/pgsrip>
 
 **PGSRip** is a command line tool that allows you to extract and convert
@@ -85,6 +85,54 @@ Rip from a folder path:
     Ripping subtitles  [####################################]  100%  ~/medias/mymedia.mkv [4:en]
     11 PGS subtitles ripped from 9 files
 
+#### Subtitle Type Filtering
+
+PGSRip supports filtering subtitles by type based on MKVToolNix metadata:
+
+**Filter by specific types:**
+
+    # Extract only FULL subtitles (regular, non-forced, non-SDH)
+    $ pgsrip --full-only mymedia.mkv
+
+    # Extract only FORCED subtitles (for foreign language text/signs)
+    $ pgsrip --forced-only mymedia.mkv
+
+    # Extract only SDH subtitles (for Deaf and Hard of hearing)
+    $ pgsrip --sdh-only mymedia.mkv
+
+**Filter by combined types:**
+
+    # Extract FULL and FORCED subtitles together
+    $ pgsrip --forced-included mymedia.mkv
+
+    # Extract FULL and SDH subtitles together
+    $ pgsrip --sdh-included mymedia.mkv
+
+    # Extract FULL, FORCED and SDH subtitles together
+    $ pgsrip --all-included mymedia.mkv
+
+**Advanced examples:**
+
+    # Extract forced subtitles in multiple languages
+    $ pgsrip --forced-only -l en -l fr -l de ~/Movies/
+
+    # Extract full French and forced English subtitles
+    $ pgsrip --forced-included -l fr -l en mymedia.mkv
+
+    # Extract all subtitle types (full, forced, SDH) in multiple languages
+    $ pgsrip --all-included -l fr -l en mymedia.mkv
+
+**Output file naming:**
+
+- Files are named with format: `<movie>.<language>.<type>.srt`
+- Examples: `movie.en.forced.srt`, `movie.fr.full.srt`, `movie.en.sdh.srt`
+
+**Subtitle type detection:**
+
+- **FORCED**: Detected via MKV `forced_track` metadata
+- **SDH**: Auto-detected from track names containing "SDH", "CC", "Hearing Impaired", or "Deaf"
+- **FULL**: Regular subtitles that are neither forced nor SDH
+
 Using docker:
 
     $ docker run -it --rm -v /medias:/medias -u $(id -u username):$(id -g username) ratoaq2/pgsrip -l en -l de -l pt-BR -l pt /medias
@@ -94,11 +142,30 @@ Using docker:
 
 ### API
 
-``` python
-from pgsrip import pgsrip, Mkv, Options
-from babelfish import Language
+    from pgsrip import pgsrip, Mkv, Options, SubtitleTypeFilter
+    from babelfish import Language
 
-media = Mkv('/subtitle/path/mymedia.mkv')
-options = Options(languages={Language('eng')}, overwrite=True, one_per_lang=False)
-pgsrip.rip(media, options)
-```
+    media = Mkv('/subtitle/path/mymedia.mkv')
+    options = Options(languages={Language('eng')},
+                      overwrite=True,
+                      one_per_lang=False,
+                      subtitle_type_filter=SubtitleTypeFilter.FORCED_ONLY)
+    pgsrip.rip(media, options)
+
+## Technical Details
+
+### Subtitle Type Detection
+
+PGSRip automatically detects subtitle types based on MKVToolNix metadata:
+
+- **FORCED**: Detected via the `forced_track` property in MKV metadata
+- **SDH**: Detected by analyzing track names for keywords like "SDH", "Hearing Impaired", "Deaf", or "CC"
+- **FULL**: Regular subtitles that are neither forced nor SDH, or explicitly marked as "Full"/"Complete"
+
+The filtering options work as follows:
+
+- `--full-only`: Only FULL subtitles (excludes forced and SDH)
+- `--forced-included`: FULL + FORCED subtitles
+- `--forced-only`: Only FORCED subtitles
+- `--sdh-included`: FULL + SDH subtitles
+- `--sdh-only`: Only SDH subtitles

--- a/pgsrip/__init__.py
+++ b/pgsrip/__init__.py
@@ -1,17 +1,24 @@
 """Rip your PGS subtitles."""
-from importlib import metadata
-
-__title__ = metadata.metadata(__package__)['name']
-__version__ = metadata.version(__package__)
-__short_version__ = '.'.join(__version__.split('.')[:2])
-__author__ = metadata.metadata(__package__)['author']
-__license__ = metadata.metadata(__package__)['license']
-__url__ = metadata.metadata(__package__)['home_page']
-
-del metadata
+try:
+    from importlib import metadata
+    __title__ = metadata.metadata(__package__)['name']
+    __version__ = metadata.version(__package__)
+    __short_version__ = '.'.join(__version__.split('.')[:2])
+    __author__ = metadata.metadata(__package__)['author']
+    __license__ = metadata.metadata(__package__)['license']
+    __url__ = metadata.metadata(__package__)['home_page']
+    del metadata
+except:
+    # Fallback for development environment
+    __title__ = 'pgsrip'
+    __version__ = '1.0.0'
+    __short_version__ = '1.0'
+    __author__ = 'pgsrip'
+    __license__ = 'MIT'
+    __url__ = 'https://github.com/ratoaq2/pgsrip'
 
 from . import api as pgsrip
 from .media import Media, Pgs
 from .mkv import Mkv
-from .options import Options
+from .options import Options, SubtitleTypeFilter
 from .sup import Sup

--- a/pgsrip/media.py
+++ b/pgsrip/media.py
@@ -145,6 +145,7 @@ class Pgs:
         self.data_reader = data_reader
         self.temp_folder = temp_folder
         self._items: typing.Optional[typing.List[PgsSubtitleItem]] = None
+        self.track_type: typing.Optional[str] = None  # Will be set by MkvPgs
 
     @property
     def language(self):
@@ -152,7 +153,8 @@ class Pgs:
 
     @property
     def srt_path(self):
-        return self.media_path.translate(number=0, extension='srt')
+        # Include track type in filename if available
+        return self.media_path.translate(number=0, extension='srt', subtitle_type=self.track_type)
 
     @property
     def items(self):

--- a/pgsrip/media_path.py
+++ b/pgsrip/media_path.py
@@ -13,13 +13,14 @@ logger = logging.getLogger(__name__)
 
 class MediaPath:
 
-    def __init__(self, path: str):
+    def __init__(self, path: str, subtitle_type: typing.Optional[str] = None):
         file_part, extension = os.path.splitext(path)
         base_path, code = os.path.splitext(file_part)
         self.number = 0
         self.language = Language.fromcleanit(code[1:] if code else 'und')
         self.extension = extension[1:] if extension else None
         self.base_path = base_path if self.language else file_part
+        self.subtitle_type = subtitle_type
 
     def __repr__(self):
         return f'<{self.__class__.__name__} [{str(self)}]>'
@@ -28,6 +29,7 @@ class MediaPath:
         return f'{self.base_path}' \
                f'{f"-{self.number}" if self.number else ""}' \
                f'{f".{str(self.language)}" if self.language else ""}' \
+               f'{f".{self.subtitle_type}" if self.subtitle_type else ""}' \
                f'{f".{self.extension}" if self.extension else ""}'
 
     @property
@@ -50,7 +52,8 @@ class MediaPath:
     def translate(self,
                   language: typing.Optional[Language] = None,
                   extension: typing.Optional[str] = None,
-                  number: typing.Optional[int] = None):
+                  number: typing.Optional[int] = None,
+                  subtitle_type: typing.Optional[str] = None):
         media_path = copy(self)
         if number is not None:
             media_path.number = number
@@ -58,4 +61,6 @@ class MediaPath:
             media_path.language = language
         if extension is not None:
             media_path.extension = extension
+        if subtitle_type is not None:
+            media_path.subtitle_type = subtitle_type
         return media_path

--- a/pgsrip/mkv.py
+++ b/pgsrip/mkv.py
@@ -10,7 +10,7 @@ from trakit.api import trakit
 
 from pgsrip.media import Media, Pgs
 from pgsrip.media_path import MediaPath
-from pgsrip.options import Options
+from pgsrip.options import Options, SubtitleTypeFilter
 
 logger = logging.getLogger(__name__)
 
@@ -68,11 +68,43 @@ class MkvTrack:
     def forced(self):
         return self.properties.get('forced_track')
 
+    @property
+    def is_sdh(self):
+        """Check if subtitle is SDH (Subtitles for the Deaf and Hard of hearing)"""
+        track_name = self.properties.get('track_name', '').lower()
+        return any(term in track_name for term in ['sdh', 'hearing impaired', 'deaf', 'cc'])
+
+    @property
+    def is_full(self):
+        """Check if subtitle is marked as FULL"""
+        track_name = self.properties.get('track_name', '').lower()
+        # Consider a subtitle as FULL if it's not explicitly forced and not SDH
+        # or if it's explicitly marked as full/complete
+        return (not self.forced and not self.is_sdh) or any(term in track_name for term in ['full', 'complete'])
+
+    def matches_type_filter(self, subtitle_filter: SubtitleTypeFilter) -> bool:
+        """Check if this track matches the subtitle type filter"""
+        if subtitle_filter == SubtitleTypeFilter.ALL:
+            return True
+        elif subtitle_filter == SubtitleTypeFilter.FULL_ONLY:
+            return self.is_full and not self.forced and not self.is_sdh
+        elif subtitle_filter == SubtitleTypeFilter.FORCED_INCLUDED:
+            return self.is_full or self.forced
+        elif subtitle_filter == SubtitleTypeFilter.FORCED_ONLY:
+            return self.forced
+        elif subtitle_filter == SubtitleTypeFilter.SDH_INCLUDED:
+            return self.is_full or self.is_sdh
+        elif subtitle_filter == SubtitleTypeFilter.SDH_ONLY:
+            return self.is_sdh
+        elif subtitle_filter == SubtitleTypeFilter.ALL_INCLUDED:
+            return self.is_full or self.forced or self.is_sdh
+        return True
+
     def __repr__(self):
         return f'<{self.__class__.__name__} [{str(self)}]>'
 
     def __str__(self):
-        return f'{self.id}:{self.type}:{self.codec}:{self.language}:{self.enabled}:{self.forced}'
+        return f'{self.id}:{self.type}:{self.codec}:{self.language}:{self.enabled}:{self.forced}:{self.is_full}:{self.is_sdh}'
 
 
 class Mkv(Media):
@@ -89,22 +121,58 @@ class Mkv(Media):
         tracks.sort(key=lambda x: x.forced)
         tracks.sort(key=lambda x: x.id)
         selected_languages: typing.Dict[Language, int] = {}
+        # For certain filters, we need to track different types separately
+        selected_types_per_lang: typing.Dict[typing.Tuple[Language, str], int] = {}
+
         for t in tracks:
             language = t.language
             if options.languages and language not in options.languages:
                 logger.debug('Filtering out track %s:%s in %s', t.id, language, self)
                 continue
 
-            if options.one_per_lang and language in selected_languages:
-                logger.debug('Skipping track %s:%s in %s', t.id, language, self)
+            # Apply subtitle type filter
+            if not t.matches_type_filter(options.subtitle_type_filter):
+                logger.debug('Filtering out track %s:%s (type filter: %s) in %s',
+                           t.id, language, options.subtitle_type_filter.value, self)
+                continue
+
+            # Determine track type for naming and selection logic
+            track_type = 'forced' if t.forced else ('sdh' if t.is_sdh else 'full')
+            type_key = (language, track_type)
+
+            # For mixed filters (forced-included, sdh-included, all-included), allow multiple types per language
+            # For single type filters or default, use original one_per_lang logic
+            should_skip_duplicate = False
+            if options.subtitle_type_filter in [SubtitleTypeFilter.FORCED_INCLUDED, SubtitleTypeFilter.SDH_INCLUDED, SubtitleTypeFilter.ALL_INCLUDED]:
+                # Allow one track per type per language
+                if type_key in selected_types_per_lang:
+                    should_skip_duplicate = True
+            else:
+                # Original logic: one track per language
+                if options.one_per_lang and language in selected_languages:
+                    should_skip_duplicate = True
+
+            if should_skip_duplicate:
+                logger.debug('Skipping track %s:%s (%s) - already have this type/language', t.id, language, track_type)
                 continue
 
             if not language:
                 logger.debug('Skipping unknown language track %s in %s', t.id, self)
                 continue
 
-            pgs = MkvPgs(self.media_path, t.id, language, selected_languages.get(language, 0), options=options)
+            # Use track type for numbering when we have mixed types
+            if options.subtitle_type_filter in [SubtitleTypeFilter.FORCED_INCLUDED, SubtitleTypeFilter.SDH_INCLUDED, SubtitleTypeFilter.ALL_INCLUDED]:
+                track_number = selected_types_per_lang.get(type_key, 0)
+                selected_types_per_lang[type_key] = track_number + 1
+            else:
+                track_number = selected_languages.get(language, 0)
+                selected_languages[language] = track_number + 1
+
+            pgs = MkvPgs(self.media_path, t.id, language, track_number, options=options)
+            # Store track type in the pgs object for later use in naming
+            pgs.track_type = track_type
+            # Also update the media_path to include the track type
+            pgs.media_path = pgs.media_path.translate(subtitle_type=track_type)
             if pgs.matches(options):
-                logger.debug('Selecting track %s:%s in %s', t.id, language, self)
+                logger.debug('Selecting track %s:%s (%s) in %s', t.id, language, track_type, self)
                 yield pgs
-                selected_languages[language] = selected_languages.get(language, 0) + 1

--- a/pgsrip/options.py
+++ b/pgsrip/options.py
@@ -33,6 +33,17 @@ class TesseractPageSegmentationMode(enum.Enum):
     RAW_LINE = 13
 
 
+@enum.unique
+class SubtitleTypeFilter(enum.Enum):
+    ALL = 'all'
+    FULL_ONLY = 'full-only'
+    FORCED_INCLUDED = 'forced-included'
+    FORCED_ONLY = 'forced-only'
+    SDH_INCLUDED = 'sdh-included'
+    SDH_ONLY = 'sdh-only'
+    ALL_INCLUDED = 'all-included'
+
+
 class Options:
 
     def __init__(self,
@@ -49,7 +60,8 @@ class Options:
                  tesseract_oem: typing.Optional[TesseractEngineMode] = None,
                  tesseract_psm: typing.Optional[TesseractPageSegmentationMode] = None,
                  age: typing.Optional[timedelta] = None,
-                 srt_age: typing.Optional[timedelta] = None):
+                 srt_age: typing.Optional[timedelta] = None,
+                 subtitle_type_filter: SubtitleTypeFilter = SubtitleTypeFilter.ALL):
         self.config = Config.from_path(config_path) if config_path else Config()
         self.languages = languages or set()
         self.tags = tags or {'default'}
@@ -64,6 +76,7 @@ class Options:
         self.tesseract_psm = tesseract_psm
         self.age = age
         self.srt_age = srt_age
+        self.subtitle_type_filter = subtitle_type_filter
 
     def __repr__(self):
         return f'<{self.__class__.__name__} [{self}]>'
@@ -81,4 +94,5 @@ class Options:
                 f'tesseract_oem:{self.tesseract_oem}, '
                 f'tesseract_psm:{self.tesseract_psm}, '
                 f'age:{self.age}, '
-                f'srt_age:{self.srt_age}')
+                f'srt_age:{self.srt_age}, '
+                f'subtitle_type_filter:{self.subtitle_type_filter}')


### PR DESCRIPTION
Add support for filtering PGS subtitles by type based on MKVToolNix metadata:

- --full-only: Extract only FULL subtitles (regular, non-forced, non-SDH)
- --forced-only: Extract only FORCED subtitles (for foreign language text/signs)
- --forced-included: Extract FULL and FORCED subtitles together
- --sdh-only: Extract only SDH subtitles (for Deaf and Hard of hearing)
- --sdh-included: Extract FULL and SDH subtitles together
- --all-included: Extract FULL, FORCED and SDH subtitles together