### PR TITLE
Fix Dockerfile to remove tessdata .git directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
 WORKDIR /data
 
 RUN git clone --progress --depth 1 --branch ${TESSDATA_VERSION} https://github.com/tesseract-ocr/tessdata_best.git \
-    && mv tessdata_best tessdata \
-    && rm -rf .git
+    && rm -rf tessdata_best/.git \
+    && mv tessdata_best tessdata
 
 
 FROM python:3.13-slim as builder


### PR DESCRIPTION
Fixes #141

This PR updates the `tesseract-image` stage in the Dockerfile so that the `.git`
directory from the `tessdata_best` clone is removed before the directory is
renamed to `tessdata`.

Previously, `rm -rf .git` ran in `/data`, leaving `/data/tessdata/.git` intact
and causing the full Git history (~1.3 GB) to be copied into `/usr/src/tessdata`
in the final image.

Changes:
- Replace `rm -rf .git` with `rm -rf tessdata_best/.git` before `mv tessdata_best tessdata`.

This reduces the final image size from ~4 GB to ~2.67 GB.