### PR TITLE
Remove unused X11 libraries from final Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/gpg-pub-moritzbunkus.gpg] https://mkvtoolnix.download/debian/ bookworm main" >> /etc/apt/sources.list.d/mkvtoolnix.download.list \
     && echo "deb-src [signed-by=/usr/share/keyrings/gpg-pub-moritzbunkus.gpg] https://mkvtoolnix.download/debian/ bookworm main" >> /etc/apt/sources.list.d/mkvtoolnix.download.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg libsm6 libxext6 tesseract-ocr mkvtoolnix \
+    && apt-get install -y --no-install-recommends ffmpeg tesseract-ocr mkvtoolnix \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fixes #143

### Summary

This PR removes two unnecessary X11-related libraries from the final Docker image: `libsm6` and `libxext6`.

`pgsrip` is a command-line application, and neither Tesseract (in non-GUI usage) nor MKVToolNix require these X Window System libraries at runtime. Keeping them installed only increases the image size without providing any benefit.

### Changes

- Update the final image `apt-get install` line to drop `libsm6` and `libxext6`:

```diff
-    && apt-get install -y --no-install-recommends ffmpeg libsm6 libxext6 tesseract-ocr mkvtoolnix \
+    && apt-get install -y --no-install-recommends ffmpeg tesseract-ocr mkvtoolnix \
```

### Rationale

* `libsm6` and `libxext6` are X11 libraries typically needed for GUI applications.
* `pgsrip` uses Tesseract and MKVToolNix from the command line only.
* The MKVToolNix requirements documentation does not list these libraries as dependencies.
* Removing unused libraries keeps the image smaller and reduces the surface area of the runtime environment.