### PR TITLE
Dockerfile: simplify builder stage (remove unused curl/gpg, drop unnecessary poetry install)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,16 +26,10 @@ ENV PYTHONFAULTHANDLER=1 \
     POETRY_VERSION=1.8.3 \
     POETRY_VIRTUALENVS_CREATE=0
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl gpg \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install "poetry==$POETRY_VERSION"
+RUN python -m pip install --no-cache-dir "poetry==${POETRY_VERSION}"
 
 WORKDIR /app
 COPY poetry.lock pyproject.toml README.md /app/
-RUN poetry install --no-interaction --no-ansi --only main
 COPY pgsrip/ /app/pgsrip/
 RUN poetry build --no-interaction --no-ansi
 


### PR DESCRIPTION
Fixes #145

### Summary

This PR simplifies the Dockerfile **builder** stage to reduce build time and image layer size without changing the produced artifacts.

### Changes

* Remove unused `curl` and `gpg` packages from the `builder` stage (which are only required in the final stage).
* Remove the `poetry install --only main` step in the `builder` stage, since the stage only runs `poetry build` and does not run tests or execute the project.

### Rationale

These steps do not contribute to the build output (`/app/dist`), but they add extra package installs and dependency resolution during the image build.