### PR TITLE
Add support for LLM-based transcriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Version](https://img.shields.io/pypi/v/pgsrip.svg)](https://pypi.python.org/pypi
     <https://github.com/ratoaq2/pgsrip>
 
 **PGSRip** is a command line tool that allows you to extract and convert
-PGS subtitles into SRT format. This tool requires MKVToolNix and
-tesseract-ocr and tessdata (<https://github.com/tesseract-ocr/tessdata>
-or <https://github.com/tesseract-ocr/tessdata_best>)
+PGS subtitles into SRT format. This tool requires MKVToolNix and a OCR
+mechanism, which may be tesseract-ocr and tessdata (<https://github.com/tesseract-ocr/tessdata>
+or <https://github.com/tesseract-ocr/tessdata_best>), or any
+OpenAI-compatible LLM endpoint such as <https://github.com/ggml-org/llama.cpp>.
 
 ## Installation
 
@@ -57,9 +58,16 @@ If you prefer to build the docker image Build Docker:
 
 ### CLI
 
-Rip from a .mkv:
+Rip from a .mkv using Tesseract:
 
     $ pgsrip mymedia.mkv
+    3 PGS subtitles collected from 1 file
+    Ripping subtitles  [####################################]  100%  mymedia.mkv [5:de]
+    3 PGS subtitles ripped from 1 file
+
+Rip from a .mkv using llama-server:
+
+    $ pgsrip --llm-endpoint http://127.0.0.1:8080/v1 mymedia.mkv
     3 PGS subtitles collected from 1 file
     Ripping subtitles  [####################################]  100%  mymedia.mkv [5:de]
     3 PGS subtitles ripped from 1 file

--- a/pgsrip/cli.py
+++ b/pgsrip/cli.py
@@ -4,6 +4,7 @@ import re
 import typing
 from datetime import timedelta
 from types import TracebackType
+from urllib.parse import urlsplit
 
 from babelfish import Error as BabelfishError, Language
 
@@ -73,16 +74,31 @@ class AgeParamType(click.ParamType):
         return timedelta(**{k: int(v) for k, v in match.groupdict('0').items()})
 
 
+class URLParamType(click.ParamType):
+    name = 'url'
+
+    def convert(self, value, param, ctx):
+        try:
+            result = urlsplit(value)
+            if not all([result.scheme, result.netloc]):
+                self.fail(f'{value} is not a valid URL', param, ctx)
+            return result
+        except Exception:
+            self.fail(f'{value} is not a valid URL', param, ctx)
+
+
 LANGUAGE = LanguageParamType()
 AGE = AgeParamType()
+URL = URLParamType()
 
 
 @click.command()
 @click.option('-c', '--config', type=click.Path(), help='cleanit configuration path to be used')
 @click.option('-l', '--language', type=LANGUAGE, multiple=True, help='Language as IETF code, '
               'e.g. en, pt-BR (can be used multiple times).')
-@click.option('-t', '--tag', required=False, multiple=True, help='Rule tags to be used, '
-              'e.g. ocr, tidy, no-sdh, no-style, no-lyrics, no-spam (can be used multiple times). ')
+@click.option('-t', '--tag', required=False, multiple=True, help='Rule tags to be used for OCR postprocessing, '
+              'e.g. "ocr", "tidy", "no-sdh", "no-style", "no-lyrics", "no-spam" (can be used multiple times). '
+              'If unspecified, "default" will be used. Pass "none" to disable.')
 @click.option('-e', '--encoding', help='Save subtitles using the following encoding.')
 @click.option('-a', '--age', type=AGE, help='Filter videos newer than AGE, e.g. 12h, 1w2d.')
 @click.option('-A', '--srt-age', type=AGE, help='Filter videos which srt subtitles are newer than AGE, e.g. 12h, 1w2d.')
@@ -94,6 +110,11 @@ AGE = AgeParamType()
 @click.option('--keep-temp-files', is_flag=True, help='Do not delete temporary files created, '
                                                       'e.g. extracted sup files, generated png files '
                                                       'and other useful debug files')
+@click.option('--llm-endpoint', type=URL, help='OpenAI-compatible LLM API endpoint URL')
+@click.option('--llm-model', help='LLM model name to use for OCR')
+@click.option('--llm-api-key', help='LLM endpoint API key')
+@click.option('--llm-prompt', help='LLM prompt')
+@click.option('--llm-temp', help='LLM temperature')
 @click.option('--debug', is_flag=True, help='Print useful information for debugging and for reporting bugs.')
 @click.option('-v', '--verbose', count=True, help='Display debug messages')
 @click.argument('path', type=click.Path(), required=True, nargs=-1)
@@ -106,9 +127,14 @@ def pgsrip(config: typing.Optional[str],
            srt_age: typing.Optional[timedelta],
            force: bool,
            all: bool,
-           debug: bool,
            max_workers: typing.Optional[int],
            keep_temp_files: bool,
+           llm_endpoint: typing.Optional[str],
+           llm_model: typing.Optional[str],
+           llm_api_key: typing.Optional[str],
+           llm_prompt: typing.Optional[str],
+           llm_temp: typing.Optional[float],
+           debug: bool,
            verbose: int,
            path: typing.Tuple[str]):
     if debug:
@@ -116,7 +142,11 @@ def pgsrip(config: typing.Optional[str],
         handler.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
         logger.addHandler(handler)
         logger.setLevel(logging.DEBUG)
-        logger.info(f'Tesseract version: {tess.get_tesseract_version()}')
+        try:
+            tess_version = tess.get_tesseract_version()
+        except tess.TesseractNotFoundError:
+            tess_version = 'unavailable'
+        logger.info(f'Tesseract version: {tess_version}')
         logger.info(f'Tesseract data: {os.getenv("TESSDATA_PREFIX")}')
 
     if config and (not os.path.isfile(config) or os.path.isdir(config)):
@@ -125,17 +155,22 @@ def pgsrip(config: typing.Optional[str],
 
     options = Options(config_path=config,
                       languages=set(language or []),
-                      tags=set(tag or []),
+                      tags=tag,
                       encoding=encoding,
                       overwrite=force,
                       one_per_lang=not all,
                       keep_temp_files=keep_temp_files,
                       max_workers=max_workers,
                       age=age,
-                      srt_age=srt_age)
+                      srt_age=srt_age,
+                      llm_model=llm_model,
+                      llm_endpoint=llm_endpoint,
+                      llm_api_key=llm_api_key,
+                      llm_prompt=llm_prompt,
+                      llm_temp=llm_temp)
 
     rules = options.config.select_rules(tags=options.tags, languages=options.languages)
-    if not rules:
+    if not rules and tag != ('none',):
         values = tuple(options.tags) + tuple(str(lang) for lang in options.languages)
         click.echo(f"No rules defined for {click.style(', '.join(values), bold=True)}")
         return

--- a/pgsrip/core.py
+++ b/pgsrip/core.py
@@ -5,7 +5,7 @@ import typing
 from pgsrip.media import Media, Pgs
 from pgsrip.mkv import Mkv
 from pgsrip.options import Options
-from pgsrip.ripper import PgsToSrtRipper
+from pgsrip.ripper import PgsToSrtRipper, LlmPgsToSrtRipper
 from pgsrip.sup import Sup
 
 
@@ -65,9 +65,14 @@ def rip_pgs(pgs: Pgs, options: Options):
             if not p.matches(options):
                 return False
 
+            if options.llm_endpoint:
+                ripper = LlmPgsToSrtRipper(p, options)
+            else:
+                ripper = PgsToSrtRipper(p, options)
+
             rules = options.config.select_rules(tags=options.tags, languages={p.language})
-            srt = PgsToSrtRipper(p, options).rip(lambda t: rules.apply(t, '')[0])
-            srt.save(encoding=options.encoding)
+            ripper.rip(rules.clean).save(encoding=options.encoding)
+
             return True
     except Exception as e:
         logger.warning('Error while trying to rip %s: <%s> [%s]',

--- a/pgsrip/options.py
+++ b/pgsrip/options.py
@@ -1,6 +1,7 @@
 import enum
 import typing
 from datetime import timedelta
+from urllib.parse import SplitResult as URLSplitResult
 
 from babelfish import Language
 
@@ -49,7 +50,12 @@ class Options:
                  tesseract_oem: typing.Optional[TesseractEngineMode] = None,
                  tesseract_psm: typing.Optional[TesseractPageSegmentationMode] = None,
                  age: typing.Optional[timedelta] = None,
-                 srt_age: typing.Optional[timedelta] = None):
+                 srt_age: typing.Optional[timedelta] = None,
+                 llm_endpoint: typing.Optional[URLSplitResult] = None,
+                 llm_model: typing.Optional[str] = None,
+                 llm_api_key: typing.Optional[str] = None,
+                 llm_prompt: typing.Optional[str] = None,
+                 llm_temp: typing.Optional[float] = None):
         self.config = Config.from_path(config_path) if config_path else Config()
         self.languages = languages or set()
         self.tags = tags or {'default'}
@@ -64,6 +70,11 @@ class Options:
         self.tesseract_psm = tesseract_psm
         self.age = age
         self.srt_age = srt_age
+        self.llm_endpoint = llm_endpoint
+        self.llm_model = llm_model
+        self.llm_api_key = llm_api_key
+        self.llm_prompt = llm_prompt
+        self.llm_temp = llm_temp
 
     def __repr__(self):
         return f'<{self.__class__.__name__} [{self}]>'
@@ -81,4 +92,8 @@ class Options:
                 f'tesseract_oem:{self.tesseract_oem}, '
                 f'tesseract_psm:{self.tesseract_psm}, '
                 f'age:{self.age}, '
-                f'srt_age:{self.srt_age}')
+                f'srt_age:{self.srt_age}, '
+                f'llm_endpoint:{self.llm_endpoint}, '
+                f'llm_model:{self.llm_model}, '
+                f'llm_api_key:{"***" if self.llm_api_key else None}',
+                f'llm_prompt:{self.llm_prompt}')

--- a/pgsrip/ripper.py
+++ b/pgsrip/ripper.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import http.client
 import json
 import logging
 import os
@@ -234,4 +236,130 @@ class PgsToSrtRipper:
 
         subs.clean_indexes()
 
+        return subs
+
+
+class LlmPgsToSrtRipper:
+
+    def __init__(self, pgs: Pgs, options: Options):
+        self.pgs = pgs
+        self.llm_endpoint = options.llm_endpoint
+        self.llm_model = options.llm_model or 'unspecified'
+        self.llm_api_key = options.llm_api_key
+        self.llm_prompt = options.llm_prompt or 'Text transcription'
+        if pgs.language:
+            self.llm_prompt = f'{self.llm_prompt.rstrip(". ")}. Language: {pgs.language}'
+        self.llm_temp = options.llm_temp
+        self.keep_temp_files = options.keep_temp_files
+
+    def prepare_payload(self, image) -> dict:
+        _, buffer = cv2.imencode('.png', image)
+        image_base64 = base64.b64encode(buffer.tobytes()).decode('utf-8')
+
+        payload = {
+            'model': self.llm_model,
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': [
+                        {
+                            'type': 'image_url',
+                            'image_url': {
+                                'url': f'data:image/png;base64,{image_base64}'
+                            }
+                        },
+                        {
+                            'type': 'text',
+                            'text': self.llm_prompt
+                        }
+                    ]
+                }
+            ],
+            'max_tokens': 4096,
+            'chat_template_kwargs': {
+                # Under no circumstances makes sense to enable thinking for basic OCRing
+                'enable_thinking': False
+            }
+        }
+        if self.llm_temp is not None:
+            payload['temperature'] = self.llm_temp
+
+        return payload
+
+    def call_llm_api(self, payload: dict) -> dict:
+        body = json.dumps(payload)
+
+        parsed = self.llm_endpoint
+        host = parsed.hostname
+        port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+        path = (parsed.path or '').rstrip('/') + '/chat/completions'
+        if parsed.query:
+            path = f'{path}?{parsed.query}'
+
+        if parsed.scheme == 'https':
+            conn = http.client.HTTPSConnection(host, port, timeout=60)
+        else:
+            conn = http.client.HTTPConnection(host, port, timeout=60)
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Content-Length': str(len(body))
+        }
+        if self.llm_api_key:
+            headers['Authorization'] = f'Bearer {self.llm_api_key}'
+
+        try:
+            conn.request('POST', path, body=body, headers=headers)
+            response = conn.getresponse()
+            response_data = response.read().decode('utf-8')
+
+            if response.status != 200:
+                logger.error('LLM API error %d: %s', response.status, response_data)
+                return {}
+
+            result = json.loads(response_data)
+            return result
+
+        except Exception as e:
+            logger.error('LLM API call failed: %s', e)
+            return {}
+        finally:
+            conn.close()
+
+    def rip(self, post_process: typing.Callable[[str], str]):
+        subs = SubRipFile(path=str(self.pgs.media_path.translate(extension='srt')))
+        debug_file = None
+
+        if self.keep_temp_files:
+            debug_file = os.path.join(self.pgs.temp_folder,
+                                      f'{os.path.basename(subs.path)}-llm-debug.txt')
+            logger.debug('Writing LLM results to %s', debug_file)
+
+        for item in self.pgs.items:
+            payload = self.prepare_payload(item.image.data)
+            response = self.call_llm_api(payload)
+
+            try:
+                text = response['choices'][0]['message']['content'].strip()
+            except KeyError:
+                logger.error('Unexpected LLM response: %s', response)
+                continue
+
+            if post_process and text:
+                text = post_process(text)
+
+            if text:
+                sub_item = SubRipItem(0, item.start, item.end, text)
+                subs.append(sub_item)
+
+            if self.keep_temp_files and debug_file:
+                with open(debug_file, mode='a', encoding='utf-8') as f:
+                    f.write(f'--- {item} ---\n')
+                    f.write('PAYLOAD:\n')
+                    json.dump(payload, f, indent=2)
+                    f.write('\n\nRESPONSE:\n')
+                    json.dump(response, f, indent=2)
+                    f.write(f'\n\nEXTRACTED TEXT:\n{text}\n\n')
+
+        subs.clean_indexes()
         return subs


### PR DESCRIPTION
This PR adds support for calling a OCR model using any OpenAI-compatible endpoint. I'm personally using it with [GLM-OCR](https://huggingface.co/ggml-org/GLM-OCR-GGUF), which yields a fairly satisfactory result on my local machine.

The changes are fairly minimal, implementing simply a new `LlmPgsToSrtRipper` class and options for that. No new libraries are needed, using the built-in `http.client`.